### PR TITLE
Add the button to the actions bar for better usability

### DIFF
--- a/assets/publish.link_preview.css
+++ b/assets/publish.link_preview.css
@@ -13,6 +13,13 @@
 	display: none;
 }
 
-#breadcrumbs .link-preview {
-	margin-left: 20px;
+.actions .link-preview {
+	background-color: #4d78b4;
+	background-image: linear-gradient(to bottom, #6f92c2 0%, #6f92c2 35%, #4d78b4 65%, #4d78b4 100%);
+
+	color: #fff;
+}
+
+.actions .link-preview:hover {
+	background-image: linear-gradient(to bottom, #6f92c2 0%, #6f92c2 15%, #4d78b4 65%, #4d78b4 100%);
 }

--- a/assets/publish.link_preview.js
+++ b/assets/publish.link_preview.js
@@ -21,18 +21,21 @@
 		var text = elem.attr('data-text');
 		
 		if (!!url) {
-			var link = $('<a />')
+			var li = $('<li />'),
+				link = $('<a />')
 				.text(text)
-				.attr('class', 'link-preview')
+				.attr('class', 'button drawer vertical-right')
 				.attr('href', url)
 				.attr('target', '_blank');
-			
-			target.after(link);
+
+			li.append(link);
+
+			target.append(li);
 		}
 	};
-	
+
 	var init = function () {
-		target = $('#context #breadcrumbs h2');
+		target = $('#context .actions');
 		return $(FIELD_CLASS).each(hookOne);
 	};
 

--- a/assets/publish.link_preview.js
+++ b/assets/publish.link_preview.js
@@ -24,7 +24,7 @@
 			var li = $('<li />'),
 				link = $('<a />')
 				.text(text)
-				.attr('class', 'button drawer vertical-right')
+				.attr('class', 'button drawer vertical-right link-preview')
 				.attr('href', url)
 				.attr('target', '_blank');
 

--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -20,6 +20,9 @@
 		<!-- None -->
 	</dependencies>
 	<releases>
+		<release version="1.2.2" date="2015-04-13" min="2.3.4" max="2.5.x">
+			- Added preview button to actions bar
+		</release>
 		<release version="1.2.1" date="2014-12-08" min="2.3.4" max="2.5.x">
 			- Added Compatibility with "Association Field"
 			- Allow ID-qualifier for associated entries


### PR DESCRIPTION
Hey! Awesome extension, super useful.

However, I didn't find it very intuitive that the link sits beside the breadcrumb with similar font styling to the breadcrumb. I thought perhaps it should be with the other actionable links, to the right.

Feel free to discard if you disagree, but I have found it more intuitive on the right.

Cheers!