### PR TITLE
Replace continue by break for php 7.3

### DIFF
--- a/fields/field.link_preview.php
+++ b/fields/field.link_preview.php
@@ -338,6 +338,7 @@
 					$relatedFields = $field->get('related_field_id');
 					$relatedData = $relatedEntry[0]->getData($relatedFields[0], false);
 					if (empty($relatedEntry) || empty($relatedFields)) {
+						value = '';
 						break;
 					}
 					

--- a/fields/field.link_preview.php
+++ b/fields/field.link_preview.php
@@ -338,7 +338,7 @@
 					$relatedFields = $field->get('related_field_id');
 					$relatedData = $relatedEntry[0]->getData($relatedFields[0], false);
 					if (empty($relatedEntry) || empty($relatedFields)) {
-						continue;
+						break;
 					}
 					
 					$value = $relatedData['handle'];


### PR DESCRIPTION
Continue cannot be used in a switch in php7.3. break must be used